### PR TITLE
hc-happ-create: interpolate env var at script runtime, not nix build …

### DIFF
--- a/happs/create/default.nix
+++ b/happs/create/default.nix
@@ -4,7 +4,7 @@ let
 
   script = pkgs.writeShellScriptBin name
   ''
-    curl -L -o happ-template.tar.gz https://github.com/holochain/react-graphql-template/archive/''${HC_HAPP_CREATE_TEMPLATE_GIT_REF:-master}.tar.gz
+    curl -L -o happ-template.tar.gz https://github.com/holochain/react-graphql-template/archive/${HC_HAPP_CREATE_TEMPLATE_GIT_REF:-master}.tar.gz
     mkdir "''${1:-"Notes-hApp-Template"}"
     tar -zxvf happ-template.tar.gz --strip-components=1 -C ./"''${1:-"Notes-hApp-Template"}"
     rm happ-template.tar.gz


### PR DESCRIPTION
…time

I obviously have a lot to learn about nix...